### PR TITLE
Precompute IDFs in scoring process

### DIFF
--- a/BM25.ts
+++ b/BM25.ts
@@ -59,10 +59,15 @@ export default function BM25(
   );
   const averageDocumentLength =
     documentLengths.reduce((a, b) => a + b, 0) / documents.length;
+  const idfByKeyword = keywords.reduce((obj, keyword) => {
+    obj[keyword] = getIDF(keyword, documents);
+    return obj;
+  }, {});
+
   const scores = documents.map((document: string, index: number) => {
     const score = keywords
       .map((keyword: string) => {
-        const inverseDocumentFrequency = getIDF(keyword, documents);
+        const inverseDocumentFrequency = idfByKeyword[keyword];
         const termFrequency = getTermFrequency(keyword, document);
         const documentLength = documentLengths[index];
         return (

--- a/BM25.ts
+++ b/BM25.ts
@@ -60,14 +60,14 @@ export default function BM25(
   const averageDocumentLength =
     documentLengths.reduce((a, b) => a + b, 0) / documents.length;
   const idfByKeyword = keywords.reduce((obj, keyword) => {
-    obj[keyword] = getIDF(keyword, documents);
+    obj.set(keyword, getIDF(keyword, documents));
     return obj;
-  }, {});
+  }, new Map<string, number>());
 
   const scores = documents.map((document: string, index: number) => {
     const score = keywords
       .map((keyword: string) => {
-        const inverseDocumentFrequency = idfByKeyword[keyword];
+        const inverseDocumentFrequency = idfByKeyword.get(keyword);
         const termFrequency = getTermFrequency(keyword, document);
         const documentLength = documentLengths[index];
         return (


### PR DESCRIPTION
Thanks for the library!

I've been prototyping something with this and found the performance on my dataset (~1200 documents, average of 240 words) wasn't quite enough for how I'd been hoping to use it, but when I profiled the code I saw that most of the time was actually being spent in the `getIDF` function, which happened to be called redundantly in the main scoring loop.

Precomputing the IDF values for each keyword like this is a pretty big performance boost, I'm seeing 80%+ faster searches on my data, down from 3.6s to 280ms with three keywords.